### PR TITLE
Use HTML div to preserve law text line breaks

### DIFF
--- a/law_article_search.py
+++ b/law_article_search.py
@@ -109,7 +109,11 @@ def display_search_results(results):
             # 조문 내용 (하이라이트 적용)
             if '내용' in result['article'] and result['article']['내용']:
                 st.markdown("**내용:**")
-                st.markdown(result['matched_content'], unsafe_allow_html=True)
+                formatted = result['matched_content'].replace('\n', '<br>')
+                st.markdown(
+                    f"<div style='white-space: pre-wrap;'>{formatted}</div>",
+                    unsafe_allow_html=True,
+                )
             
             st.markdown("</div>", unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- Wrap matched law content in a `<div>` with `white-space: pre-wrap` and replace newlines with `<br>` to keep formatting while supporting Streamlit markdown rendering.
- Maintains existing search term highlighting.

## Testing
- `python -m py_compile law_article_search.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68905128c8a0832598643d60e0c91c33